### PR TITLE
dinamically set headers

### DIFF
--- a/lib/graphql_util.rb
+++ b/lib/graphql_util.rb
@@ -54,8 +54,8 @@ module GraphqlUtil
     #
     # @return [GraphQL::Client::Response] Request Response
     #
-    def query(query, variables: {})
-      self::GRAPHQL_UTIL_CLIENT.query(query, variables: variables)
+    def query(query, variables: {}, context: {})
+      self::GRAPHQL_UTIL_CLIENT.query(query, variables: variables, context: context)
     end
   end
 end

--- a/lib/graphql_util.rb
+++ b/lib/graphql_util.rb
@@ -37,8 +37,8 @@ module GraphqlUtil
       raise "GraphqlUtil - #{const_name} is already defined, please use a different filename." if (base.const_get(const_name.upcase.to_sym).present? rescue false)
 
       base.const_set(const_name.upcase, base::GRAPHQL_UTIL_CLIENT.parse(File.open(filename).read))
-      base.define_singleton_method(const_name.downcase.to_sym) do |variables = {}|
-        base.query(base.const_get(const_name.upcase.to_sym), variables: variables)
+      base.define_singleton_method(const_name.downcase.to_sym) do |variables: {}, context: {}|
+        base.query(base.const_get(const_name.upcase.to_sym), variables: variables, context: context)
       end
     end
 
@@ -54,7 +54,7 @@ module GraphqlUtil
     #
     # @return [GraphQL::Client::Response] Request Response
     #
-    def query(query, variables: {}, context: {})
+    def query(query, variables:, context:)
       self::GRAPHQL_UTIL_CLIENT.query(query, variables: variables, context: context)
     end
   end

--- a/lib/graphql_util/client.rb
+++ b/lib/graphql_util/client.rb
@@ -11,7 +11,7 @@ class GraphqlUtil::Client < GraphQL::Client
   #
   # @return [GraphQL::Client::Response] Request Response
   #
-  def query(parsed_query, variables: {})
-    super(parsed_query, variables: variables, context: {})
+  def query(parsed_query, variables: {}, context: {})
+    super(parsed_query, variables: variables, context: context)
   end
 end

--- a/lib/graphql_util/http.rb
+++ b/lib/graphql_util/http.rb
@@ -15,7 +15,12 @@ class GraphqlUtil::Http < GraphQL::Client::HTTP
     super(endpoint) do
       def headers(context)
         context ||= {}
-        @headers.merge(context[:headers])
+
+        if context[:headers]
+          @headers.merge(context[:headers])
+        else
+          @headers
+        end
       end
     end
   end

--- a/lib/graphql_util/http.rb
+++ b/lib/graphql_util/http.rb
@@ -14,7 +14,8 @@ class GraphqlUtil::Http < GraphQL::Client::HTTP
     @headers = headers
     super(endpoint) do
       def headers(context)
-        @headers
+        context ||= {}
+        @headers.merge(context[:headers])
       end
     end
   end


### PR DESCRIPTION
Allow to set the headers dinamically when running the query/mutation instead of having it fixed during the client setup